### PR TITLE
feat: wire frontend to real backend API

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -21,6 +21,7 @@
         "@eslint/js": "^9.39.3",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
         "@types/react": "^18.2.0",
         "@types/react-dom": "^18.2.0",
         "@vitejs/plugin-react-swc": "^4.2.3",
@@ -2284,6 +2285,20 @@
         "@types/react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
       }
     },
     "node_modules/@types/aria-query": {
@@ -5239,22 +5254,6 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/yaml": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
-      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
-      "extraneous": true,
-      "license": "ISC",
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
-      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -17,6 +17,7 @@
     "@eslint/js": "^9.39.3",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/react": "^18.2.0",
     "@types/react-dom": "^18.2.0",
     "@vitejs/plugin-react-swc": "^4.2.3",

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -1,58 +1,17 @@
-import { useState } from "react";
 import Box from "@mui/material/Box";
 import Typography from "@mui/material/Typography";
 import Button from "@mui/material/Button";
 import Stack from "@mui/material/Stack";
+import Alert from "@mui/material/Alert";
 import RefreshIcon from "@mui/icons-material/Refresh";
 import { ContainerTable } from "./components/ContainerTable";
-import type { ImageCheck } from "./types";
-
-const MOCK_CHECKS: ImageCheck[] = [
-  {
-    id: 1,
-    containerName: "web-server",
-    containerId: "abc123def456",
-    imageRef: "nginx:latest",
-    localDigest: "sha256:aaa111",
-    remoteDigest: "sha256:bbb222",
-    status: "update-available",
-    checkedAt: new Date().toISOString(),
-    registry: "dockerhub",
-  },
-  {
-    id: 2,
-    containerName: "database",
-    containerId: "def456ghi789",
-    imageRef: "postgres:16",
-    localDigest: "sha256:ccc333",
-    remoteDigest: "sha256:ccc333",
-    status: "up-to-date",
-    checkedAt: new Date().toISOString(),
-    registry: "dockerhub",
-  },
-  {
-    id: 3,
-    containerName: "cache",
-    containerId: "ghi789jkl012",
-    imageRef: "redis:7-alpine",
-    localDigest: "",
-    remoteDigest: "",
-    status: "unknown",
-    checkedAt: "",
-    registry: "dockerhub",
-  },
-];
+import { useBackend } from "./hooks/useBackend";
 
 export default function App() {
-  const [checks] = useState<ImageCheck[]>(MOCK_CHECKS);
-  const [loading, setLoading] = useState(false);
+  const { checks, checkAll, loading, error, fetchChecks } = useBackend();
 
   const handleCheckAll = () => {
-    setLoading(true);
-    // TODO: Replace with real backend call in Wave 3
-    setTimeout(() => {
-      setLoading(false);
-    }, 1500);
+    checkAll();
   };
 
   return (
@@ -72,6 +31,12 @@ export default function App() {
       <Typography variant="body1" color="text.secondary" sx={{ mb: 3 }}>
         Check if your running container images have newer versions available.
       </Typography>
+
+      {error != null && (
+        <Alert severity="error" sx={{ mb: 2 }} onClose={() => fetchChecks()}>
+          {error}
+        </Alert>
+      )}
 
       <ContainerTable checks={checks} loading={loading} />
 

--- a/ui/src/__mocks__/@docker/extension-api-client.ts
+++ b/ui/src/__mocks__/@docker/extension-api-client.ts
@@ -1,0 +1,29 @@
+import { vi } from "vitest";
+
+const mockService = {
+  get: vi.fn().mockResolvedValue({ checks: [] }),
+  post: vi.fn().mockResolvedValue({
+    checks: [],
+    startedAt: new Date().toISOString(),
+  }),
+};
+
+const mockClient = {
+  extension: {
+    vm: {
+      service: mockService,
+    },
+  },
+  desktopUI: {
+    toast: {
+      success: vi.fn(),
+      error: vi.fn(),
+      warning: vi.fn(),
+    },
+  },
+  docker: {
+    cli: { exec: vi.fn() },
+  },
+};
+
+export const createDockerDesktopClient = () => mockClient;

--- a/ui/src/__tests__/App.test.tsx
+++ b/ui/src/__tests__/App.test.tsx
@@ -1,0 +1,104 @@
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import App from "../App";
+import { createDockerDesktopClient } from "@docker/extension-api-client";
+import type { ImageCheck } from "../types";
+
+const mockChecks: ImageCheck[] = [
+  {
+    id: 1,
+    containerName: "web-server",
+    containerId: "abc123def456",
+    imageRef: "nginx:latest",
+    localDigest: "sha256:aaa111",
+    remoteDigest: "sha256:bbb222",
+    status: "update-available",
+    checkedAt: new Date().toISOString(),
+    registry: "dockerhub",
+  },
+  {
+    id: 2,
+    containerName: "database",
+    containerId: "def456ghi789",
+    imageRef: "postgres:16",
+    localDigest: "sha256:ccc333",
+    remoteDigest: "sha256:ccc333",
+    status: "up-to-date",
+    checkedAt: new Date().toISOString(),
+    registry: "dockerhub",
+  },
+];
+
+function getMockService() {
+  const client = createDockerDesktopClient();
+  return client.extension.vm!.service!;
+}
+
+describe("App", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders the heading and check button", async () => {
+    render(<App />);
+    expect(screen.getByText("DockPulse")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /check now/i })).toBeInTheDocument();
+  });
+
+  it("fetches checks on mount and displays them", async () => {
+    const service = getMockService();
+    vi.mocked(service.get).mockResolvedValueOnce({ checks: mockChecks });
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(screen.getByText("web-server")).toBeInTheDocument();
+    });
+    expect(screen.getByText("database")).toBeInTheDocument();
+  });
+
+  it("calls check-all when button is clicked", async () => {
+    const service = getMockService();
+    vi.mocked(service.get).mockResolvedValueOnce({ checks: [] });
+    vi.mocked(service.post).mockResolvedValueOnce({
+      checks: mockChecks,
+      startedAt: new Date().toISOString(),
+    });
+
+    render(<App />);
+
+    const button = screen.getByRole("button", { name: /check now/i });
+    fireEvent.click(button);
+
+    await waitFor(() => {
+      expect(service.post).toHaveBeenCalledWith("/api/check-all", {});
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("web-server")).toBeInTheDocument();
+    });
+  });
+
+  it("displays error alert when fetch fails", async () => {
+    const service = getMockService();
+    vi.mocked(service.get).mockRejectedValueOnce(new Error("Connection refused"));
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Connection refused")).toBeInTheDocument();
+    });
+  });
+
+  it("shows empty state when no containers", async () => {
+    const service = getMockService();
+    vi.mocked(service.get).mockResolvedValueOnce({ checks: [] });
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("No containers found. Start some containers and check again."),
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/ui/src/hooks/useBackend.ts
+++ b/ui/src/hooks/useBackend.ts
@@ -1,24 +1,42 @@
-import { useState, useCallback } from "react";
-import type { ImageCheck } from "../types";
+import { createDockerDesktopClient } from "@docker/extension-api-client";
+import { useState, useCallback, useEffect } from "react";
+import type { ImageCheck, CheckAllResponse } from "../types";
 
-// TODO: Replace with real ddClient.extension.vm.service calls in Wave 3
+const ddClient = createDockerDesktopClient();
+
 export function useBackend() {
+  const [checks, setChecks] = useState<ImageCheck[]>([]);
   const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
-  const getChecks = useCallback(async (): Promise<ImageCheck[]> => {
-    // Placeholder -- will call ddClient.extension.vm.service.get("/api/checks")
-    return [];
+  const fetchChecks = useCallback(async () => {
+    try {
+      const result = await ddClient.extension.vm?.service?.get("/api/checks");
+      const data = result as { checks: ImageCheck[] };
+      setChecks(data.checks ?? []);
+      setError(null);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to fetch checks");
+    }
   }, []);
 
-  const checkAll = useCallback(async (): Promise<ImageCheck[]> => {
+  const checkAll = useCallback(async () => {
     setLoading(true);
+    setError(null);
     try {
-      // Placeholder -- will call ddClient.extension.vm.service.post("/api/check-all")
-      return [];
+      const result = await ddClient.extension.vm?.service?.post("/api/check-all", {});
+      const data = result as CheckAllResponse;
+      setChecks(data.checks ?? []);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Check failed");
     } finally {
       setLoading(false);
     }
   }, []);
 
-  return { getChecks, checkAll, loading };
+  useEffect(() => {
+    fetchChecks();
+  }, [fetchChecks]);
+
+  return { checks, checkAll, loading, error, fetchChecks };
 }

--- a/ui/vitest.config.ts
+++ b/ui/vitest.config.ts
@@ -5,11 +5,14 @@ import viteConfig from "./vite.config";
 export default mergeConfig(
   viteConfig,
   defineConfig({
+    define: {
+      __APP_VERSION__: JSON.stringify("0.0.0-test"),
+    },
     resolve: {
       alias: {
         "@docker/extension-api-client": path.resolve(
           __dirname,
-          "node_modules/@docker/extension-api-client/dist/index.js",
+          "src/__mocks__/@docker/extension-api-client.ts",
         ),
       },
     },


### PR DESCRIPTION
## Summary

- Replace mock data in App.tsx with real `ddClient.extension.vm.service` API calls
- `useBackend` hook manages checks state, loading, and error handling
- Auto-fetches latest checks on mount, error display via MUI Alert
- Extension API client mock for vitest (KG#81 pattern)
- 5 new App integration tests (mount fetch, check-all, error, empty state)

Closes #2

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` — 10/10 tests pass
- [ ] CI passes (fe-lint, fe-typecheck, fe-test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)