### PR TITLE
feat: multi-stage Dockerfile and Makefile targets

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -9,6 +9,7 @@ Makefile
 docs/
 node_modules/
 ui/node_modules/
+ui/build/
 ui/.vite/
 *.tar
 .env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,44 @@
 # syntax=docker/dockerfile:1
 
 # DockPulse Docker Desktop Extension
-# Multi-stage build: backend + frontend
+# Multi-stage build: Go backend + React frontend
 
-FROM alpine
+# ---------- Stage 1: Build Go backend ----------
+FROM golang:1.24-alpine AS backend-build
+WORKDIR /build
+
+COPY backend/go.mod backend/go.sum ./
+RUN go mod download
+
+COPY backend/ .
+RUN CGO_ENABLED=0 go build -ldflags="-s -w" -o dockpulse .
+
+# ---------- Stage 2: Build React frontend ----------
+FROM node:22-alpine AS frontend-build
+WORKDIR /build
+
+COPY ui/package.json ui/package-lock.json ./
+RUN npm ci
+
+COPY ui/ .
+RUN npm run build
+
+# ---------- Stage 3: Final image ----------
+FROM alpine:3.19
+
 LABEL org.opencontainers.image.title="DockPulse" \
       org.opencontainers.image.description="Check if your container images have newer versions available" \
       org.opencontainers.image.vendor="Herb Hall" \
       com.docker.desktop.extension.api.version=">= 0.3.3" \
-      com.docker.desktop.extension.icon="https://raw.githubusercontent.com/HerbHall/DockPulse/main/docker.svg" \
-      com.docker.extension.screenshots="" \
+      com.docker.desktop.extension.icon="docker.svg" \
       com.docker.extension.detailed-description="DockPulse checks your running containers against their registries and shows which images have updates available — right inside Docker Desktop." \
       com.docker.extension.publisher-url="https://github.com/HerbHall" \
+      com.docker.extension.screenshots="" \
       com.docker.extension.changelog=""
 
-# TODO: Add backend build stage
-# TODO: Add frontend build stage
-# TODO: Copy metadata.json and ui assets
+COPY metadata.json /
+COPY docker.svg /
+COPY --from=backend-build /build/dockpulse /
+COPY --from=frontend-build /build/build /ui
 
-COPY metadata.json .
+ENTRYPOINT ["/dockpulse"]

--- a/Makefile
+++ b/Makefile
@@ -27,3 +27,34 @@ push-extension:
 
 clean:
 	docker extension rm $(IMAGE) || true
+
+# Go targets
+.PHONY: go-build go-test go-lint
+
+go-build:
+	cd backend && go build ./...
+
+go-test:
+	cd backend && go test ./...
+
+go-lint:
+	cd backend && go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.1.6 run ./...
+
+# Frontend targets
+.PHONY: fe-build fe-test fe-lint fe-typecheck
+
+fe-build:
+	cd ui && npm run build
+
+fe-test:
+	cd ui && npx vitest run
+
+fe-lint:
+	cd ui && npx eslint src/
+
+fe-typecheck:
+	cd ui && npx tsc --noEmit
+
+# All checks
+.PHONY: validate
+validate: go-build go-test go-lint fe-typecheck fe-lint fe-test


### PR DESCRIPTION
## Summary

- Three-stage Docker build: Go 1.24-alpine backend, Node 22-alpine frontend, Alpine 3.19 final
- `CGO_ENABLED=0` with `-ldflags="-s -w"` for minimal static binary
- Layer caching via separate dependency/source COPY steps
- Makefile targets: `go-build`, `go-test`, `go-lint`, `fe-build`, `fe-test`, `fe-lint`, `fe-typecheck`, `validate`
- Add `ui/build/` to `.dockerignore`

Closes #10

## Test plan

- [x] `docker build --tag=dockpulse-test:dev .` builds successfully
- [x] `make go-build` and `make go-test` pass
- [ ] CI passes (all jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)