### PR TITLE
feat: add GitHub Copilot integration

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,78 @@
+# DockPulse -- Copilot Instructions
+
+Docker Desktop extension for monitoring Docker container health and performance. Queries Docker Hub v2 API directly for image digest comparison to detect outdated container images.
+
+## Tech Stack
+
+- **Backend**: Go 1.24, stdlib `net/http`, Docker Engine API (`github.com/docker/docker`), SQLite (`modernc.org/sqlite`)
+- **Frontend**: React 18, TypeScript 5, MUI v5 (pinned via `@docker/docker-mui-theme`), Vite 7, Vitest
+- **Communication**: Unix socket via `@docker/extension-api-client`
+- **Build**: Multi-stage Dockerfile, Makefile, GitHub Actions CI
+
+## Project Structure
+
+```text
+DockPulse/
+├── backend/
+│   ├── main.go                       - Server entry point (Unix socket listener)
+│   └── internal/
+│       ├── api/handler.go            - HTTP handlers (3 endpoints)
+│       ├── checker/checker.go        - Orchestrator (enumerate, compare, store)
+│       ├── docker/client.go          - Docker Engine API wrapper
+│       ├── imageref/parse.go         - Image reference parser
+│       ├── registry/                 - Registry interface + Docker Hub v2 client
+│       └── store/                    - SQLite store (models, queries, migrations)
+├── ui/
+│   └── src/
+│       ├── App.tsx                   - Main layout
+│       ├── hooks/useBackend.ts       - ddClient API calls
+│       ├── types.ts                  - Shared types
+│       └── components/               - ContainerTable, StatusChip, ErrorBoundary
+├── Dockerfile                        - Multi-stage build
+├── Makefile                          - Build/test/lint targets
+└── metadata.json                     - Docker extension metadata
+```
+
+## Code Style
+
+- Conventional commits: `feat:`, `fix:`, `refactor:`, `docs:`, `test:`, `chore:`
+- Co-author tag: `Co-Authored-By: GitHub Copilot <noreply@github.com>`
+- Go errors wrapped with context: `fmt.Errorf("operation: %w", err)`
+- Table-driven tests with `t.Run` and descriptive names
+- All lint checks must pass before committing (golangci-lint v2 for Go, ESLint for TS)
+- Backend Go commands use `cd backend` prefix (go.mod is in `backend/`, not root)
+
+## Coding Guidelines
+
+- Fix errors immediately -- never classify them as pre-existing
+- Build, test, and lint must pass before any commit
+- Never skip hooks (`--no-verify`) or force-push main
+- Validate only at system boundaries (user input, external APIs)
+- Remove unused code completely; no backwards-compatibility hacks
+- MUI v5 only: use `InputProps` (not `slotProps.input`) for TextField adornments
+- Docker extension UI reinitializes on every tab switch -- all state must come from backend
+
+## Available Resources
+
+```bash
+make validate         # Run all checks (build, test, lint, typecheck)
+make go-build         # cd backend && go build ./...
+make go-test          # cd backend && go test ./...
+make go-lint          # cd backend && golangci-lint v2 run ./...
+make fe-build         # cd ui && npm run build
+make fe-test          # cd ui && npx vitest run
+make fe-lint          # cd ui && npx eslint src/
+make fe-typecheck     # cd ui && npx tsc --noEmit
+make build-extension  # Build Docker extension image
+```
+
+## Do NOT
+
+- Add `//nolint` directives without fixing the root cause first
+- Use `any` in TypeScript or suppress TypeScript errors with `as unknown`
+- Commit generated files without regenerating them first
+- Add dependencies without updating the lock file
+- Use `panic` in library code; return errors instead
+- Store secrets, tokens, or credentials in code or config files
+- Mark work as complete when known errors remain
+- Run Go commands from the repo root -- always `cd backend` first

--- a/.github/instructions/go.instructions.md
+++ b/.github/instructions/go.instructions.md
@@ -1,0 +1,121 @@
+---
+applyTo: "backend/**/*.go"
+---
+
+# Go Coding Instructions
+
+## Error Handling
+
+Always wrap errors with context using `fmt.Errorf`:
+
+```go
+// GOOD: wraps error with context
+if err != nil {
+    return fmt.Errorf("fetch device %s: %w", id, err)
+}
+
+// BAD: discards context
+if err != nil {
+    return err
+}
+```
+
+Never return `(result, nil)` when `err != nil`. Propagate both:
+
+```go
+// GOOD: nilerr compliant
+return &Result{Message: runErr.Error()}, fmt.Errorf("run: %w", runErr)
+```
+
+## Named Returns
+
+When golangci-lint flags `unnamedResult`, add named returns. After adding names,
+change `:=` to `=` for those variables and remove redundant `var` declarations:
+
+```go
+// GOOD: named returns, = not :=
+func compute(data []float64) (score float64, detail string) {
+    switch {
+    case len(data) == 0:
+        detail = "no data"
+    default:
+        score = average(data)
+        detail = fmt.Sprintf("n=%d", len(data))
+    }
+    return score, detail
+}
+```
+
+## Lint Patterns (golangci-lint v2)
+
+Fix these before committing:
+
+- **rangeValCopy**: `for _, v := range slice` on structs >64 bytes -- use `for i := range slice { slice[i]... }`
+- **prealloc**: `var result []T` in a loop -- use `make([]T, 0, len(source))`
+- **appendCombine**: two consecutive `append()` to same slice -- combine into one call
+- **emptyStringTest**: `len(s) > 0` -- use `s != ""`
+- **httpNoBody**: `http.NewRequestWithContext(ctx, method, url, nil)` -- use `http.NoBody`
+- **bodyclose**: always close `resp.Body`, including deferred: `defer func() { _ = resp.Body.Close() }()`
+- **exhaustive**: switch on enum types must list ALL cases explicitly
+- **noctx**: use `ExecContext`, `QueryContext`, `QueryRowContext` instead of context-less variants
+- **paramTypeCombine**: `(a int, b int)` -- combine consecutive same-type params to `(a, b int)`
+- **builtinShadow**: don't use `new`, `make`, `len`, `cap`, `close`, `delete`, `copy`, `append`, `min`, `max`, `clear` as parameter names
+- **gosec G101**: constants named like credentials (containing "password", "token", "secret") need `//nolint:gosec // G101: <reason>`
+- **preferFprint**: `b.WriteString(fmt.Sprintf(...))` -- use `fmt.Fprintf(&b, ...)` instead
+- **dupBranchBody**: identical `if`/`else` branches -- remove the conditional, keep just the body
+- **sloppyReassign**: `if err = f(); err != nil` with named return `err` -- use `:=` to shadow instead
+
+## Testing
+
+Use table-driven tests with `t.Run`:
+
+```go
+func TestSomething(t *testing.T) {
+    tests := []struct {
+        name    string
+        input   string
+        want    int
+        wantErr bool
+    }{
+        {name: "valid input", input: "abc", want: 3},
+        {name: "empty input", input: "", wantErr: true},
+    }
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            got, err := Something(tt.input)
+            if (err != nil) != tt.wantErr {
+                t.Errorf("error = %v, wantErr %v", err, tt.wantErr)
+            }
+            if got != tt.want {
+                t.Errorf("got %v, want %v", got, tt.want)
+            }
+        })
+    }
+}
+```
+
+## HTTP Handlers (Go 1.22+)
+
+Use Go 1.22 enhanced `ServeMux` patterns:
+
+```go
+mux.HandleFunc("GET /items/{id}", h.getItem)
+mux.HandleFunc("POST /items", h.createItem)
+```
+
+Always name `*http.Request` parameter even if unused -- expanding stubs later requires it.
+
+## Imports
+
+Group imports in three blocks separated by blank lines:
+
+```go
+import (
+    "context"
+    "fmt"
+
+    "github.com/docker/docker/client"
+
+    "github.com/HerbHall/DockPulse/backend/internal/store"
+)
+```

--- a/.github/instructions/react.instructions.md
+++ b/.github/instructions/react.instructions.md
@@ -1,0 +1,141 @@
+---
+applyTo: "ui/**/*.{ts,tsx}"
+---
+
+# React/TypeScript Coding Instructions
+
+## Component Patterns
+
+Define props interfaces above the component, use functional components:
+
+```tsx
+interface ItemCardProps {
+    id: string
+    label: string
+    onSelect: (id: string) => void
+}
+
+export function ItemCard({ id, label, onSelect }: ItemCardProps) {
+    return <button onClick={() => onSelect(id)}>{label}</button>
+}
+```
+
+## State Management
+
+- Use `useState` for client-only UI state
+- Docker Desktop extension UI reinitializes on tab switch -- all persistent state must come from the backend via `ddClient`
+- **No `useEffect` for data syncing** -- use nullable local override instead:
+
+```tsx
+// GOOD: nullable override, no useEffect sync
+const [localOverride, setLocalOverride] = useState<string | null>(null)
+const displayValue = localOverride ?? serverValue ?? ''
+```
+
+## API Integration
+
+Always use `ddClient` from `@docker/extension-api-client`; never call `fetch` directly:
+
+```tsx
+import { createDockerDesktopClient } from '@docker/extension-api-client'
+const ddClient = createDockerDesktopClient()
+
+// GET from backend
+const result = await ddClient.extension.vm.service.get('/api/checks')
+
+// POST to backend
+await ddClient.extension.vm.service.post('/api/check-all', {})
+```
+
+## Union Return Types
+
+When a function returns a union type, add a type guard and use it at EVERY call site:
+
+```tsx
+// BAD: TS2339 -- access_token not on union
+const result = await loginApi(user, pass)
+setToken(result.access_token)
+
+// GOOD: narrow first
+const result = await loginApi(user, pass)
+if (isMFAChallenge(result)) throw new Error('unexpected MFA')
+setToken(result.access_token)
+```
+
+## TypeScript
+
+- Strict mode -- no `any`; use `unknown` with type guards
+- JSX short-circuit: `{expanded && item.details != null && <div/>}` (use `!= null`, not bare `&&` on `unknown`)
+- Unused imports: ESLint catches these even when `tsc` does not -- verify every named import is used
+
+## React Compiler Lint
+
+Do not mutate `ref.current` during render -- wrap in `useEffect`:
+
+```tsx
+// BAD: ref mutation during render
+onMessageRef.current = onMessage
+
+// GOOD: wrap in effect
+useEffect(() => { onMessageRef.current = onMessage }, [onMessage])
+```
+
+For Popper/Popover anchor elements, use callback ref with `useState` instead of `useRef`:
+
+```tsx
+// GOOD: callback ref avoids reading ref.current during render
+const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null)
+<Button ref={setAnchorEl}>Menu</Button>
+<Popper anchorEl={anchorEl} open={open}>...</Popper>
+```
+
+## MUI v5 (Docker Desktop Extensions)
+
+This project uses MUI v5 pinned via `@docker/docker-mui-theme`. Always reference MUI v5 patterns:
+
+```tsx
+// GOOD: MUI v5 TextField adornment
+<TextField InputProps={{ startAdornment: <InputAdornment position="start">...</InputAdornment> }} />
+
+// BAD: MUI v6 pattern -- does NOT work with v5
+<TextField slotProps={{ input: { startAdornment: ... } }} />
+```
+
+Use `@docker/docker-mui-theme` for theming consistency with Docker Desktop:
+
+```tsx
+import { DockerMuiThemeProvider } from '@docker/docker-mui-theme'
+
+function App() {
+    return (
+        <DockerMuiThemeProvider>
+            <CssBaseline />
+            {/* your app */}
+        </DockerMuiThemeProvider>
+    )
+}
+```
+
+## Testing
+
+Vitest + Testing Library. Use `mergeConfig` to inherit Vite plugins and defines:
+
+```ts
+// vitest.config.ts
+import { mergeConfig, defineConfig } from 'vitest/config'
+import viteConfig from './vite.config'
+
+export default mergeConfig(viteConfig, defineConfig({
+    test: { environment: 'jsdom', globals: true, setupFiles: './src/test-setup.ts' }
+}))
+```
+
+Mock `@docker/extension-api-client` via resolve alias in `vitest.config.ts` (CJS/ESM mismatch):
+
+```ts
+resolve: {
+    alias: {
+        '@docker/extension-api-client': path.resolve(__dirname, 'src/__mocks__/@docker/extension-api-client.ts')
+    }
+}
+```

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,0 +1,35 @@
+name: Copilot Setup Steps
+
+on: workflow_dispatch
+
+jobs:
+  copilot-setup-steps:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: backend/go.mod
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "lts/*"
+
+      - name: Download Go modules
+        run: go mod download
+        working-directory: backend
+
+      - name: Install frontend dependencies
+        run: npm ci
+        working-directory: ui
+
+      - name: Verify Go build
+        run: go build ./...
+        working-directory: backend
+
+      - name: Verify TypeScript compilation
+        run: npx tsc --noEmit
+        working-directory: ui

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,185 @@
+<!--
+  Scope: AGENTS.md guides the Copilot coding agent and Copilot Chat.
+  For code completion and code review patterns, see .github/copilot-instructions.md
+  and .github/instructions/*.instructions.md
+  For Claude Code, see CLAUDE.md
+-->
+
+# DockPulse
+
+Docker Desktop extension for monitoring Docker container health and performance. Queries Docker Hub v2 API directly for image digest comparison -- detects when running containers have outdated images.
+
+## Tech Stack
+
+- **Backend**: Go 1.24, stdlib `net/http`, Docker Engine API (`github.com/docker/docker`), SQLite (`modernc.org/sqlite`)
+- **Frontend**: React 18, TypeScript 5, MUI v5 (pinned via `@docker/docker-mui-theme`), Vite 7, Vitest
+- **Communication**: Unix socket via `@docker/extension-api-client` (`ddClient.extension.vm.service.get/post()`)
+- **Build**: Multi-stage Dockerfile, Makefile, GitHub Actions CI (7 parallel jobs)
+- **Platform**: Docker Desktop 4.8.0+ (Windows, macOS, Linux)
+
+## Build and Test Commands
+
+```bash
+# Full verification (run before any PR)
+make validate            # Build + test + lint + typecheck (all targets)
+
+# Backend
+make go-build            # cd backend && go build ./...
+make go-test             # cd backend && go test ./...
+make go-lint             # cd backend && golangci-lint v2 run ./...
+
+# Frontend
+make fe-build            # cd ui && npm run build
+make fe-test             # cd ui && npx vitest run
+make fe-lint             # cd ui && npx eslint src/
+make fe-typecheck        # cd ui && npx tsc --noEmit
+
+# Docker extension
+make build-extension     # Build Docker extension image
+make install-extension   # Install into Docker Desktop
+make push-extension      # Multi-arch build and push (linux/amd64 + linux/arm64)
+```
+
+## Project Structure
+
+```text
+DockPulse/
+├── backend/
+│   ├── main.go                       - Server entry point (Unix socket listener)
+│   └── internal/
+│       ├── api/handler.go            - HTTP handlers (3 endpoints)
+│       ├── checker/checker.go        - Orchestrator (enumerate, compare, store)
+│       ├── docker/client.go          - Docker Engine API wrapper
+│       ├── imageref/parse.go         - Image reference parser (registry/ns/name:tag)
+│       ├── registry/registry.go      - Registry interface
+│       ├── registry/dockerhub.go     - Docker Hub v2 client (token auth + manifest HEAD)
+│       └── store/                    - SQLite store (models, queries, migrations)
+├── ui/
+│   └── src/
+│       ├── App.tsx                   - Main layout with header, table, check button
+│       ├── hooks/useBackend.ts       - ddClient API calls (GET/POST to backend)
+│       ├── types.ts                  - Shared TypeScript types
+│       └── components/               - ContainerTable, StatusChip, ErrorBoundary
+├── .github/workflows/ci.yml         - 7-job CI pipeline
+├── metadata.json                     - Docker extension metadata
+├── Dockerfile                        - Multi-stage build (Go + Node + Alpine)
+├── Makefile                          - Build/test/lint targets
+└── docs/FEASIBILITY.md              - Original feasibility research
+```
+
+## Workflow Rules
+
+### Always Do
+
+- Create a feature branch for every change (`feature/issue-NNN-description`)
+- Use conventional commits: `feat:`, `fix:`, `refactor:`, `docs:`, `test:`, `chore:`
+- Run `make validate` before opening a PR
+- Write table-driven tests with descriptive names (Go)
+- Wrap errors with context: `fmt.Errorf("operation: %w", err)`
+- Fix every error you find, regardless of who introduced it
+- Backend Go code lives in `backend/` -- always `cd backend` before Go commands
+
+### Ask First
+
+- Adding new dependencies (check if stdlib covers the need)
+- Architectural changes (new packages, major interface changes)
+- Database schema migrations
+- Changes to CI/CD workflows
+- Removing or renaming public APIs
+- Adding new API endpoints
+
+### Never Do
+
+- Commit directly to `main` -- always use feature branches
+- Skip tests or lint checks -- even for "small changes"
+- Use `--no-verify` or `--force` flags
+- Commit secrets, credentials, or API keys
+- Add TODO comments without a linked issue number
+- Mark work as complete when build, test, or lint failures remain
+- Use `panic` in library code; return errors instead
+- Use `any` in TypeScript; use `unknown` with type guards
+
+## Core Principles
+
+These are unconditional -- no optimization or time pressure overrides them:
+
+1. **Quality**: Once found, always fix, never leave. There is no "pre-existing" error.
+2. **Verification**: Build, test, and lint must pass before any commit.
+3. **Safety**: Never force-push `main`. Never skip hooks. Never commit secrets.
+4. **Honesty**: Never mark work as complete when it is not.
+
+## Error Handling
+
+```go
+// Wrap errors with context -- every return site should add meaning
+if err != nil {
+    return fmt.Errorf("load config: %w", err)
+}
+
+// Use sentinel errors for caller-distinguishable conditions
+var ErrNotFound = errors.New("not found")
+if errors.Is(err, ErrNotFound) { ... }
+```
+
+## Testing Conventions
+
+```go
+// Table-driven tests with descriptive names
+func TestFunctionName(t *testing.T) {
+    tests := []struct {
+        name    string
+        input   string
+        want    string
+        wantErr bool
+    }{
+        {
+            name:  "valid input returns expected output",
+            input: "example",
+            want:  "result",
+        },
+        {
+            name:    "empty input returns error",
+            input:   "",
+            wantErr: true,
+        },
+    }
+
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            got, err := FunctionName(tt.input)
+            if (err != nil) != tt.wantErr {
+                t.Errorf("FunctionName() error = %v, wantErr %v", err, tt.wantErr)
+            }
+            if got != tt.want {
+                t.Errorf("FunctionName() = %v, want %v", got, tt.want)
+            }
+        })
+    }
+}
+```
+
+## React/TypeScript Conventions
+
+```tsx
+// MUI v5 (pinned via @docker/docker-mui-theme) -- use InputProps, NOT slotProps
+<TextField InputProps={{ startAdornment: <InputAdornment position="start">...</InputAdornment> }} />
+
+// Docker Desktop extension API -- use ddClient, never raw fetch
+import { createDockerDesktopClient } from '@docker/extension-api-client'
+const ddClient = createDockerDesktopClient()
+const result = await ddClient.extension.vm.service.get('/api/checks')
+```
+
+## Commit Format
+
+```text
+feat: add container health monitoring endpoint
+
+Implements periodic health checks with configurable intervals.
+
+Closes #42
+Co-Authored-By: GitHub Copilot <copilot@github.com>
+```
+
+Types: `feat` (new feature), `fix` (bug fix), `refactor` (no behavior change),
+`docs` (documentation only), `test` (tests only), `chore` (build/tooling).


### PR DESCRIPTION
## Summary

- Add `AGENTS.md` with three-tier boundaries for Copilot coding agent
- Add `.github/copilot-instructions.md` with project context
- Add `.github/workflows/copilot-setup-steps.yml` for coding agent setup
- Add `.github/instructions/go.instructions.md` for Go patterns (scoped to `backend/`)
- Add `.github/instructions/react.instructions.md` for React/TS patterns (scoped to `ui/`)

## Test plan

- [ ] Verify Copilot completions respect .instructions.md patterns
- [ ] Assign Copilot to a simple issue and verify setup-steps runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)